### PR TITLE
Added prompt option if wanted

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ node_modules
 .vscode-test/
 dist/
 *.vsix
+
+.env

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 1.4.0
+
+- Add option to prompt for the barrel file name when generating a barrel file for a folder ([#16](https://github.com/mikededo/dartBarrelFileGenerator/issues/16)).
+
 ## 1.3.1
 
 - Fix files not exporting when suffixed with folder name ([#10](https://github.com/mikededo/dartBarrelFileGenerator/issues/10))

--- a/package.json
+++ b/package.json
@@ -54,8 +54,8 @@
           "dartBarrelFileGenerator.promptName": {
             "title": "Open input on file generation",
             "type": "boolean",
-            "default": true,
-            "description": "Prompt for file name"
+            "default": false,
+            "description": "get promted asking for the name of the barrel file that will be created"
           },
           "dartBarrelFileGenerator.excludeFreezed": {
             "title": "Exclude freezed (.freezed.dart) files",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,12 @@
       {
         "title": "Dart Barrel File Generator",
         "properties": {
+          "dartBarrelFileGenerator.promptName": {
+            "title": "Open input on file generation",
+            "type": "boolean",
+            "default": true,
+            "description": "Prompt for file name"
+          },
           "dartBarrelFileGenerator.excludeFreezed": {
             "title": "Exclude freezed (.freezed.dart) files",
             "type": "boolean",


### PR DESCRIPTION
A new option has been added that, if true, will prompt the user when creating the barrel file. It is a feature that only works with the option of generating the barrel file for a single folder, since it does not have much sense to use it in the other option.

- Option can be toggled in the settings with the name of `promptName`, as a `boolean` type of setting.
- If the input returns `undefined`, the folder name is used.

Closes #16.