### PR TITLE
Exclude custom patterns

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,12 @@
             "type": "boolean",
             "default": true,
             "description": "Exclude .g.dart files"
+          },
+          "dartBarrelFileGenerator.excludeFileList": {
+            "title": "Additional patterns to exclude",
+            "type": "array",
+            "default": [],
+            "description": "Add the file patterns that you want to exclude (as glob patterns)"
           }
         }
       }

--- a/src/helpers/constants.ts
+++ b/src/helpers/constants.ts
@@ -5,7 +5,8 @@ export const CONFIGURATIONS = {
   values: {
     PROMPT_NAME: 'promptName',
     EXCLUDE_FREEZED: 'excludeFreezed',
-    EXCLUDE_GENERATED: 'excludeGenerated'
+    EXCLUDE_GENERATED: 'excludeGenerated',
+    EXCLUDE_FILES: 'excludeFileList'
   },
   input: {
     canSelectMany: false,

--- a/src/helpers/functions.ts
+++ b/src/helpers/functions.ts
@@ -1,3 +1,4 @@
+import minimatch = require('minimatch');
 import { isEmpty, isNil } from 'lodash';
 import { posix, sep } from 'path';
 import { window, workspace } from 'vscode';
@@ -46,6 +47,16 @@ export const isBarrelFile = (dirName: string, fileName: string) =>
   FILE_REGEX.base(dirName).test(fileName);
 
 /**
+ * Checks if the given file name matches the given glob
+ *
+ * @param fileName The file to check for
+ * @param glob The glob to compare the string with
+ * @returns Whether it matches the glob or not
+ */
+export const matchesGlob = (fileName: string, glob: string): boolean =>
+  minimatch(fileName, glob);
+
+/**
  * Sorts the file names alphabetically
  */
 export const fileSort = (a: string, b: string): number =>
@@ -88,7 +99,8 @@ export const shouldExport = (
       return !getConfig(CONFIGURATIONS.values.EXCLUDE_GENERATED);
     }
 
-    return true;
+    const globs: Array<string> = getConfig(CONFIGURATIONS.values.EXCLUDE_FILES);
+    return globs.every((glob) => !matchesGlob(posixPath, glob));
   }
 
   return false;


### PR DESCRIPTION
Option that allows the users to exclude custom glob patterns from the generated file.

Closes #18.