### PR TITLE
Allow exclusion of directory paths from having a barrel file generated

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,9 @@ You can also exclude `.freezed.dart` and `.g.dart` (generated) files by modifyin
 - `dartBarrelFileGenerator.excludeFreezed: false` (by default).
 - `dartBarrelFileGenerator.excludeGenerated: false` (by default).
 
-Additionally, you can create a list of glob file patterns to exclude with the `dartBarrelFileGenerator.excludeFileList`.
+You can exclude files from being added to a barrel file. Create a list of glob file patterns to exclude with the `dartBarrelFileGenerator.excludeFileList`.
+
+Similarly, you can exclude a directory from having a barrel file generated. Create a list of glob directory patterns to exclude with the `dartBarrelFileGenerator.excludeDirList`.
 
 ### Custom file name
 

--- a/package.json
+++ b/package.json
@@ -70,10 +70,16 @@
             "description": "Exclude .g.dart files"
           },
           "dartBarrelFileGenerator.excludeFileList": {
-            "title": "Additional patterns to exclude",
+            "title": "Additional patterns to exclude files",
             "type": "array",
             "default": [],
-            "description": "Add the file patterns that you want to exclude (as glob patterns)"
+            "description": "Add the file patterns that you want to exclude (as glob patterns). Excluded files will not be added to the barrel file."
+          },
+          "dartBarrelFileGenerator.excludeDirList": {
+            "title": "Additional patterns to exclude directories",
+            "type": "array",
+            "default": [],
+            "description": "Add the directory patterns that you want to exclude (as glob patterns). A barrel file will not be generated for these directories."
           }
         }
       }

--- a/src/helpers/constants.ts
+++ b/src/helpers/constants.ts
@@ -6,7 +6,8 @@ export const CONFIGURATIONS = {
     PROMPT_NAME: 'promptName',
     EXCLUDE_FREEZED: 'excludeFreezed',
     EXCLUDE_GENERATED: 'excludeGenerated',
-    EXCLUDE_FILES: 'excludeFileList'
+    EXCLUDE_FILES: 'excludeFileList',
+    EXCLUDE_DIRS: 'excludeDirList'
   },
   input: {
     canSelectMany: false,

--- a/src/helpers/extension.ts
+++ b/src/helpers/extension.ts
@@ -10,6 +10,7 @@ import {
   getConfig,
   getFolderNameFromDialog,
   shouldExport,
+  shouldExportDir,
   toOsSpecificPath,
   toPosixPath
 } from './functions';
@@ -131,7 +132,9 @@ const generate = async (targetPath: string): Promise<string> => {
         files.push(curr.name);
       }
     } else if (curr.isDirectory()) {
-      dirs.add(curr.name);
+      if (shouldExportDir(curr.name)) {
+        dirs.add(curr.name);
+      }
     }
   }
 

--- a/src/helpers/functions.ts
+++ b/src/helpers/functions.ts
@@ -107,6 +107,20 @@ export const shouldExport = (
 };
 
 /**
+ * Checks if the given `posixPath` is not excluded by any configuration
+ *
+ * @param posixPath The path to check
+ * @returns If the given `posixPath` should be added to the list of
+ * exports
+ */
+export const shouldExportDir = (
+  posixPath: PosixPath
+): boolean => {
+  const globs: Array<string> = getConfig(CONFIGURATIONS.values.EXCLUDE_DIRS);
+  return globs.every((glob) => !matchesGlob(posixPath, glob));
+};
+
+/**
  * Returns the configuration value of the given config value
  *
  * @param name Configuration value name


### PR DESCRIPTION
When using the 'Current Folder and Nested Folders' generation option, there is no way to exclude a directory from having a barrel file generated. excludeFileList allows excluding file patterns from being added to a barrel, but not for a barrel being generated for a directory.

We have platform specific implementations in platform_impl subdirectories throughout our project. Files in these subdirectories are conditionally imported depending on the platform being targeted.

Even if we exclude all files inside platform_impl/ directories with excludeFileList, an empty platform_impl.dart is still generated inside that subdirectory.

This PR adds an excludeDirList option which acts similarly to excludeFileList, except the list of globs excludes directories from having a barrel file generated for them. Inside this list I add the glob `**/platform_impl` and a barrel file is no longer generated when using the recursive option.
