### PR TITLE
chore: added renovate action

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -1,0 +1,15 @@
+name: Renovate
+on:
+  schedule:
+    - cron: '0 0 * * *'
+jobs:
+  renovate:
+    runs-on: ubtuntu-latest
+    steps:
+      - uses: actions/checkout@master 
+      - name: Run renovate
+        uses: docker://renovate/renovate:slim
+        env:
+          RENOVATE_REPOSITORIES: mikededo/dartBarrelFileGenerator
+          RENOVATE_TOKEN: ${{ secrets.RENOVATE_TOKEN }}
+          RENOVATE_AUTOMERGE: false


### PR DESCRIPTION
Adds the GitHub action configuration for the `renovate` bot to run on daily basis.

---

Closes #25.