### PR TITLE
feat: set custom name for nested folders

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ By default, the extension will create a new file named as the folder name, appen
 
 - `dartBarrelFileGenerator.promptName: false` (by default).
 
-Whenever you create a new barrel file, a prompt will appear to ask for the file name. It only works when creating a barrel file for a single folder, since it does not have much sense having it for the other option.
+Whenever you create a new barrel file, a prompt will appear to ask for the file name. It can be used for both options.
 
 > **Note**: When entering the name, the `.dart` extension is not required.
 

--- a/src/helpers/context.ts
+++ b/src/helpers/context.ts
@@ -20,6 +20,8 @@ class GeneratorContext {
   private type?: GEN_TYPE;
   private startTimestamp?: number;
 
+  public customBarrelName?: string;
+
   constructor() {
     this.channel = window.createOutputChannel('DartBarrelFile');
 
@@ -34,6 +36,7 @@ class GeneratorContext {
     this.startTimestamp = undefined;
     this.path = undefined;
     this.type = undefined;
+    this.customBarrelName = undefined;
   }
 
   get activePath(): Uri {

--- a/src/helpers/extension.ts
+++ b/src/helpers/extension.ts
@@ -19,8 +19,6 @@ import {
  * Validates if the given `uri` is valid to generate a barrel file and,
  * if so, generates a barrel file in it
  *
- * @param uri The selected Uri to generate the barrel file
- * @param recursive If the barrel files should be generated recursively
  * @returns A promise with the path where the barrel file will be written
  * @throws {Error} If the selected `uri` is not valid
  */
@@ -105,22 +103,25 @@ const generate = async (targetPath: string): Promise<string> => {
   // This could be optional
   const splitDir = targetPath.split('/');
 
-  // If the user has set the promptName option and it is not the
-  // recursive case, ask for the name
-  let barrelFileName: string = splitDir[splitDir.length - 1];
+  // If the user has set the promptName option, use always such name
+  let barrelFileName: string =
+    Context.customBarrelName ?? splitDir[splitDir.length - 1];
 
+  // If there's a customBarrelName, it means that the user has already
+  // been prompted
   if (
-    Context.activeType === GEN_TYPE.REGULAR &&
+    !Context.customBarrelName &&
     getConfig(CONFIGURATIONS.values.PROMPT_NAME)
   ) {
     const result = await window.showInputBox({
-      title: 'Barrel file name',
+      title: `Barrel file name (${Context.customBarrelName})`,
       prompt:
         'Enter the name of the barrel file without the extension. If no name is entered, the folder name will be used',
       placeHolder: 'Ex: index'
     });
 
     barrelFileName = result ? result : barrelFileName;
+    Context.customBarrelName = barrelFileName;
   }
 
   const files = [];


### PR DESCRIPTION
It was a previous decision not allowing to generate a custom barrel file name with `promptName` option selected. However, the option has been updated so that it works both with `generate current` and `generate current and nested`.

Fixes #54.