### PR TITLE
feat!: add `defaultBarrelName` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ You can also exclude `.freezed.dart` and `.g.dart` (generated) files by modifyin
 
 Additionally, you can create a list of glob file patterns to exclude with the `dartBarrelFileGenerator.excludeFileList`.
 
+### Default barrel file name
+
+The extension will create a barrel file with the `<folder-name>.dart` by default. This behaviour can be changed if the `dartBarrelFileGenerator.defaultBarrelName` option is set. By changing this option, whenever a barrel file is created, it will use the name set in the configuration instead of the default.
+
+> **Note**: If the name contains any whitespace, such will be replaced by `_`.
+
 ### Custom file name
 
 By default, the extension will create a new file named as the folder name, appended by the `.dart` extension. However, if you want to set the name, you can activate the following option:

--- a/package.json
+++ b/package.json
@@ -51,6 +51,15 @@
       {
         "title": "Dart Barrel File Generator",
         "properties": {
+          "dartBarrelFileGenerator.defaultBarrelName": {
+            "title": "Default barrel file name",
+            "type": [
+              "string",
+              "null"
+            ],
+            "default": null,
+            "markdownDescription": "The default name for the barrel file is `<folder-name>.dart`. You can override this name by setting a custom name. If there's any whitespace in the name it will be replaced by a '-' and the name **will be transformed to lowercase**."
+          },
           "dartBarrelFileGenerator.promptName": {
             "title": "Open input on file generation",
             "type": "boolean",

--- a/src/helpers/constants.ts
+++ b/src/helpers/constants.ts
@@ -3,6 +3,7 @@ import { OpenDialogOptions } from 'vscode';
 export const CONFIGURATIONS = {
   key: 'dartBarrelFileGenerator',
   values: {
+    DEFAULT_NAME: 'defaultBarrelName',
     PROMPT_NAME: 'promptName',
     EXCLUDE_FREEZED: 'excludeFreezed',
     EXCLUDE_GENERATED: 'excludeGenerated',

--- a/src/helpers/extension.ts
+++ b/src/helpers/extension.ts
@@ -94,11 +94,18 @@ const writeBarrelFile = (
 };
 
 /**
- *
  * @param targetPath The target path of the barrel file
- * @returns A promise with the path of the written barrel file
+ * @returns A promise with the name of the barrel file
  */
-const generate = async (targetPath: string): Promise<string> => {
+const getBarrelFile = async (targetPath: string): Promise<string> => {
+  // Check if the user has the defaultBarrelName config set
+  const defaultBarrelName = getConfig<string>(
+    CONFIGURATIONS.values.DEFAULT_NAME
+  );
+  if (defaultBarrelName) {
+    return defaultBarrelName.replace(/ /g, '_').toLowerCase();
+  }
+
   // Selected target is in the current workspace
   // This could be optional
   const splitDir = targetPath.split('/');
@@ -123,6 +130,17 @@ const generate = async (targetPath: string): Promise<string> => {
     barrelFileName = result ? result : barrelFileName;
     Context.customBarrelName = barrelFileName;
   }
+
+  return barrelFileName;
+};
+
+/**
+ *
+ * @param targetPath The target path of the barrel file
+ * @returns A promise with the path of the written barrel file
+ */
+const generate = async (targetPath: string): Promise<string> => {
+  const barrelFileName = await getBarrelFile(targetPath);
 
   const files = [];
   const dirs = new Set();

--- a/src/helpers/functions.ts
+++ b/src/helpers/functions.ts
@@ -124,7 +124,7 @@ export const shouldExportDir = (posixPath: PosixPath): boolean => {
  * @param name Configuration value name
  * @returns The configuration value if any
  */
-export const getConfig = (name: string): any | undefined =>
+export const getConfig = <T = any>(name: string): T | undefined =>
   workspace.getConfiguration().get([CONFIGURATIONS.key, name].join('.'));
 
 export const formatDate = (date: Date = new Date()) =>


### PR DESCRIPTION
This new option allows the developer to choose a new "default" name when the extension is run. This is a shortcut for when the `propmtName` option is set, and the same name is always used.

Closes #54.