### PR TITLE
feat!: prepend and append folder name options

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,6 +94,18 @@
             "type": "array",
             "default": [],
             "description": "Add the directory patterns that you want to exclude (as glob patterns). A barrel file will not be generated for these directories."
+          },
+          "dartBarrelFileGenerator.prependFolderName": {
+            "title": "Prepend name of the folder to the generated file",
+            "type": "boolean",
+            "default": false,
+            "description": "Prepend the name of the folder to the generated files, e.g.: <folder-name>_<barrel-file>.dart."
+          },
+          "dartBarrelFileGenerator.appendFolderName": {
+            "title": "Append name of the folder to the generated file",
+            "type": "boolean",
+            "default": false,
+            "description": "Append the name of the folder to the generated files, e.g.: <barrel-file>_<folder-name>.dart."
           }
         }
       }

--- a/src/helpers/constants.ts
+++ b/src/helpers/constants.ts
@@ -8,7 +8,9 @@ export const CONFIGURATIONS = {
     EXCLUDE_FREEZED: 'excludeFreezed',
     EXCLUDE_GENERATED: 'excludeGenerated',
     EXCLUDE_FILES: 'excludeFileList',
-    EXCLUDE_DIRS: 'excludeDirList'
+    EXCLUDE_DIRS: 'excludeDirList',
+    PREPEND_FOLDER: 'prependFolderName',
+    APPEND_FOLDER: 'appendFolderName'
   },
   input: {
     canSelectMany: false,

--- a/src/helpers/extension.ts
+++ b/src/helpers/extension.ts
@@ -128,17 +128,27 @@ const writeBarrelFile = (
  * @returns A promise with the name of the barrel file
  */
 const getBarrelFile = async (targetPath: string): Promise<string> => {
+  // Check if prepend or append is wanted
+  const shouldAppend = getConfig<boolean>(CONFIGURATIONS.values.APPEND_FOLDER);
+  const shouldPrepend = getConfig<boolean>(
+    CONFIGURATIONS.values.PREPEND_FOLDER
+  );
+
+  // Selected target is in the current workspace
+  // This could be optional
+  const splitDir = targetPath.split('/');
+  const prependedDir = shouldPrepend ? `${splitDir[splitDir.length - 1]}_` : '';
+  const appendedDir = shouldAppend ? `_${splitDir[splitDir.length - 1]}` : '';
+
   // Check if the user has the defaultBarrelName config set
   const defaultBarrelName = getConfig<string>(
     CONFIGURATIONS.values.DEFAULT_NAME
   );
   if (defaultBarrelName) {
-    return defaultBarrelName.replace(/ /g, '_').toLowerCase();
+    return `${prependedDir}${defaultBarrelName
+      .replace(/ /g, '_')
+      .toLowerCase()}${appendedDir}`;
   }
-
-  // Selected target is in the current workspace
-  // This could be optional
-  const splitDir = targetPath.split('/');
 
   // If the user has set the promptName option, use always such name
   let barrelFileName: string =
@@ -161,7 +171,7 @@ const getBarrelFile = async (targetPath: string): Promise<string> => {
     Context.customBarrelName = barrelFileName;
   }
 
-  return barrelFileName;
+  return `${prependedDir}${barrelFileName}${appendedDir}`;
 };
 
 /**


### PR DESCRIPTION
BREAKING CHANGE: Adds two new configuration options.

- `prependFolderName`: When generating the barrel file, it will add the name of the folder at the beginning of the file generated.
- `appendFolderName`: When generating the barrel file, it will add the name of the folder at the end of the file generated.

Closes #69
