### PR TITLE
feat: exclude empty generated barrel files

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ VSCode extension that generate barrel files for folders containing dart files.
 
 ## Installation
 
-Dart Barrel File Generator either by [searching for the extension in VSCode](https://code.visualstudio.com/docs/editor/extension-gallery#_search-for-an-extension) or from the [marketplace](https://marketplace.visualstudio.com/).
+Dart Barrel File Generator either by
+[searching for the extension in VSCode](https://code.visualstudio.com/docs/editor/extension-gallery#_search-for-an-extension)
+or from the [marketplace](https://marketplace.visualstudio.com/).
 
 ## Overview
 
@@ -12,11 +14,14 @@ It can create barrel files only two the selected folder
 
 ![current-and-only-demo](https://raw.githubusercontent.com/mikededo/dartBarrelFileGenerator/master/assets/current-only.gif)
 
-It creates a barrel files for the selected folder and all the nested folders from the selected. Likewise, it also adds the nested folder barrel file to its parent barrel file.
+It creates a barrel file for the selected folder and all the nested folders from
+the selected. Likewise, it also adds the nested folder barrel file to its parent
+barrel file.
 
 ![current-and-nested-demo](https://raw.githubusercontent.com/mikededo/dartBarrelFileGenerator/master/assets/current-and-nested.gif)
 
-Alternatively, the extension can create a barrel file with all the names of the nested folders (for each subfolder), without creating additional barrel files.
+Alternatively, the extension can create a barrel file with all the names of the
+nested folders (for each subfolder), without creating additional barrel files.
 
 ![current-with-subfolders-demo](https://raw.githubusercontent.com/mikededo/dartBarrelFileGenerator/master/assets/current-with-subfolders.gif)
 
@@ -27,39 +32,48 @@ Alternatively, the extension can create a barrel file with all the names of the 
 | `GDBF: Current Folder Only`        | Creates a barrel file for the selected folder                 |
 | `GDBF: Current and Nested Folders` | Creates a barrel file for the selected and its nested folders |
 
-Both commands can be used by typing in the command palette. It will then ask you to choose a folder. If it is done from the folder tree, it will use the selected folder as the root folder.
+Both commands can be used by typing in the command palette. It will then ask you to
+choose a folder. If it is done from the folder tree, it will use the selected
+folder as the root folder.
 
 ## Options
 
 ### Excluding files
 
-You can also exclude `.freezed.dart` and `.g.dart` (generated) files by modifying the following options in your settings:
+You can also exclude `.freezed.dart` and `.g.dart` (generated) files by modifying the
+following options in your settings:
 
 - `dartBarrelFileGenerator.excludeFreezed: false` (by default).
 - `dartBarrelFileGenerator.excludeGenerated: false` (by default).
 
 It is also possible to exclude glob patterns:
 
-- For files, you can add a list of file globs in the `dartBarrelFile.excludeFileList` option.
-- For directories, you can add a list of directories globs in the `dartBarrelFile.excludeDirList` option.
+- For files, you can add a list of file globs in the `dartBarrelFile.excludeFileList`
+  option.
+- For directories, you can add a list of directories globs in the
+  `dartBarrelFile.excludeDirList` option.
 
 ### Default barrel file name
 
-The extension will create a barrel file with the `<folder-name>.dart` by default. This behaviour can be changed if the `dartBarrelFileGenerator.defaultBarrelName` option is set. By changing this option, whenever a barrel file is created, it will use the name set in the configuration instead of the default.
+The extension will create a barrel file with the `<folder-name>.dart` by default. This
+behaviour can be changed if the `dartBarrelFileGenerator.defaultBarrelName` option is
+set. By changing this option, whenever a barrel file is created, it will use the name
+set in the configuration instead of the default.
 
 > **Note**: If the name contains any whitespace, such will be replaced by `_`.
 
 ### Custom file name
 
-By default, the extension will create a new file named as the folder name, appended by the `.dart` extension. However, if you want to set the name, you can activate the following option:
+By default, the extension will create a new file named as the folder name, appended by
+the `.dart` extension. However, if you want to set the name, you can activate the
+following option:
 
 - `dartBarrelFileGenerator.promptName: false` (by default).
 
-Whenever you create a new barrel file, a prompt will appear to ask for the file name. It can be used for both options.
+Whenever you create a new barrel file, a prompt will appear to ask for the file name.
+It can be used for both options.
 
 > **Note**: When entering the name, the `.dart` extension is not required.
-
-### A
 
 ## Attributions
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,13 @@ It can be used for both options.
 
 > **Note**: When entering the name, the `.dart` extension is not required.
 
+### Other options
+
+- Skipping empty folders: by default, `dartBarrelFileGenerator` will not
+  generate a barrel file for a folder that does not have any file to export. You
+  can change this behaviour by setting `dartBarrelFileGenerator.skipEmpty` to
+  `false`. 
+
 ## Attributions
 
 Extension icon made by [Freepik](https://www.flaticon.com/authors/freepik) from [flaticon](www.flaticon.com).

--- a/package.json
+++ b/package.json
@@ -106,6 +106,12 @@
             "type": "boolean",
             "default": false,
             "markdownDescription": "Append the name of the folder to the generated files, e.g.: `<barrel-file>_<folder-name>.dart`."
+          },
+          "dartBarrelFileGenerator.skipEmpty": {
+            "title": "Skip empty folders",
+            "type": "boolean",
+            "default": true,
+            "description": "Skip generating barrel files for folders that are empty (or do not contain any valid dart file)"
           }
         }
       }

--- a/src/helpers/constants.ts
+++ b/src/helpers/constants.ts
@@ -3,14 +3,15 @@ import { OpenDialogOptions } from 'vscode';
 export const CONFIGURATIONS = {
   key: 'dartBarrelFileGenerator',
   values: {
+    APPEND_FOLDER: 'appendFolderName',
     DEFAULT_NAME: 'defaultBarrelName',
-    PROMPT_NAME: 'promptName',
+    EXCLUDE_DIRS: 'excludeDirList',
+    EXCLUDE_FILES: 'excludeFileList',
     EXCLUDE_FREEZED: 'excludeFreezed',
     EXCLUDE_GENERATED: 'excludeGenerated',
-    EXCLUDE_FILES: 'excludeFileList',
-    EXCLUDE_DIRS: 'excludeDirList',
     PREPEND_FOLDER: 'prependFolderName',
-    APPEND_FOLDER: 'appendFolderName'
+    PROMPT_NAME: 'promptName',
+    SKIP_EMPTY: 'skipEmpty'
   },
   input: {
     canSelectMany: false,

--- a/src/helpers/constants.ts
+++ b/src/helpers/constants.ts
@@ -20,8 +20,6 @@ export const CONFIGURATIONS = {
   } as Partial<OpenDialogOptions>
 };
 
-export type GenerationType = 'REGULAR' | 'REGULAR_SUBFOLDERS' | 'RECURSIVE';
-
 export const FILE_REGEX = {
   /**
    * Used to check whether the current file name has a

--- a/src/helpers/context.ts
+++ b/src/helpers/context.ts
@@ -1,7 +1,7 @@
 import { isNil } from 'lodash';
 import { OutputChannel, Uri, window } from 'vscode';
 
-import { GenerationType } from './constants';
+import { GenerationType } from './types';
 import { formatDate } from './functions';
 
 type InitParms = {

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -1,5 +1,6 @@
-import { CONFIGURATIONS, FILE_REGEX, GenerationType } from './constants';
 import Context from './context';
+import { CONFIGURATIONS, FILE_REGEX } from './constants';
+import { GenerationType } from './types';
 import { validateAndGenerate } from './extension';
 
 export { CONFIGURATIONS, Context, FILE_REGEX, validateAndGenerate };

--- a/src/helpers/types.ts
+++ b/src/helpers/types.ts
@@ -1,0 +1,3 @@
+export type GenerationType = 'REGULAR' | 'REGULAR_SUBFOLDERS' | 'RECURSIVE';
+
+export type Maybe<T> = T | undefined;


### PR DESCRIPTION
Introduction of a new option that, by default, will skip generated dart barrel
files that do not contain any file (this works recursively, aswell). This option
can be toggled with:

- `dartBarrelFileGenerator.skipEmpty`: `default [true]`

Fixes #78
